### PR TITLE
Also accept wide string literals as translation macro arguments

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -341,35 +341,35 @@ inline const wxString& wxGetTranslation(const char *str1,
 namespace wxTransImplStrict
 {
 
-// Wrapper functions that only accept string literals as arguments,
-// not variables, not char* pointers.
-template<size_t N>
-const wxString& wxUnderscoreWrapper(const char (&msg)[N])
+// Wrapper functions that only accept string literals (regular or wide) as
+// arguments, not variables, not char* pointers, not wchar_t* pointers.
+template<size_t N, typename T>
+const wxString& wxUnderscoreWrapper(const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg));
 }
 
-template<size_t M, size_t N>
-const wxString& wxPluralWrapper(const char (&msg)[M],
-                                const char (&plural)[N],
+template<size_t M, size_t N, typename T>
+const wxString& wxPluralWrapper(const T (&msg)[M],
+                                const T (&plural)[N],
                                 int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count);
 }
 
-template<size_t M, size_t N>
-const wxString& wxGettextInContextWrapper(const char (&ctx)[M],
-                                          const char (&msg)[N])
+template<size_t M, size_t N, typename T>
+const wxString& wxGettextInContextWrapper(const T (&ctx)[M],
+                                          const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
                             wxTRANS_INPUT_STR(ctx));
 }
 
-template<size_t L, size_t M, size_t N>
-const wxString& wxGettextInContextPluralWrapper(const char (&ctx)[L],
-                                                const char (&msg)[M],
-                                                const char (&plural)[N],
+template<size_t L, size_t M, size_t N, typename T>
+const wxString& wxGettextInContextPluralWrapper(const T (&ctx)[L],
+                                                const T (&msg)[M],
+                                                const T (&plural)[N],
                                                 int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -320,6 +320,12 @@ MyFrame::MyFrame()
     macro_menu->Append(INTERNAT_MACRO_8, wxGETTEXT_IN_CONTEXT_PLURAL("context_2", "sing", "plur", 1));
     macro_menu->Append(INTERNAT_MACRO_9, wxGETTEXT_IN_CONTEXT_PLURAL("context_2", "sing", "plur", 2));
 
+    // Also wide strings can be used:
+    _(L"item");
+    wxGETTEXT_IN_CONTEXT(L"context", L"item");
+    wxPLURAL(L"sing", L"plur", 3);
+    wxGETTEXT_IN_CONTEXT_PLURAL(L"context", L"sing", L"plur", 3);
+
     wxMenu *help_menu = new wxMenu;
 #ifdef USE_COREUTILS_MO
     help_menu->Append(wxID_HELP, _("Show coreutils &help"));


### PR DESCRIPTION
Not accepting them was an undeliberate regression introduced in PR #24957. There weren't any such calls in wx's own tests or samples, so now adding some to the internat sample to prevent a similar regression in the future.