### PR TITLE
Fix wxMSW build with wxUSE_UXTHEME==0

### DIFF
--- a/include/wx/msw/private/customdraw.h
+++ b/include/wx/msw/private/customdraw.h
@@ -78,9 +78,11 @@ public:
     // need to be called any more.
     void UseHeaderThemeColors(HWND hwndHdr)
     {
+#if wxUSE_UXTHEME
         auto theme = wxUxThemeHandle::NewAtStdDPI(hwndHdr, L"Header");
 
         m_attr.SetTextColour(theme.GetColour(HP_HEADERITEM, TMT_TEXTCOLOR));
+#endif
 
         // Note that TMT_FILLCOLOR doesn't seem to exist in this theme but the
         // correct background colour is already used in "ItemsView" theme by

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -200,6 +200,7 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
         // Theme colour would be light, so don't use it.
         attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
     }
+#if wxUSE_UXTHEME
     else
     {
         // NB: use EDIT, not COMBOBOX (the latter works in XP but not Vista)
@@ -208,6 +209,7 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
         if ( !attrs.colBg.IsOk() )
             attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
     }
+#endif
 
     return attrs;
 }

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -718,8 +718,8 @@ HandleMenuMessage(WXLRESULT* result,
                                   buf, mii.cch, drawTextFlags, rcItem,
                                   &textOpts);
             }
-#endif
             return true;
+#endif
     }
 
     return false;

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -452,6 +452,7 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
     if ( wxMSWImpl::AllowDarkModeForWindow(hwnd, true) )
         wxLogTrace(TRACE_DARKMODE, "Allow dark mode for %p failed", hwnd);
 
+#if wxUSE_UXTHEME
     if ( themeName || themeId )
     {
         HRESULT hr = ::SetWindowTheme(hwnd, themeName, themeId);
@@ -461,6 +462,10 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
                                            hwnd, themeName, themeId), hr);
         }
     }
+#else
+    wxUnusedVar(themeName);
+    wxUnusedVar(themeId);
+#endif
 }
 
 wxColour GetColour(wxSystemColour index)
@@ -633,6 +638,7 @@ HandleMenuMessage(WXLRESULT* result,
             }
             return true;
 
+#if wxUSE_UXTHEME
         case WM_MENUBAR_DRAWMENUITEM:
             if ( auto* const drawMenuItem = (MenuBarDrawMenuItem*)lParam )
             {
@@ -712,6 +718,7 @@ HandleMenuMessage(WXLRESULT* result,
                                   buf, mii.cch, drawTextFlags, rcItem,
                                   &textOpts);
             }
+#endif
             return true;
     }
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -631,6 +631,7 @@ wxVisualAttributes wxListCtrl::GetDefaultAttributes() const
 {
     wxVisualAttributes attrs = GetClassDefaultAttributes(GetWindowVariant());
 
+#if wxUSE_UXTHEME
     if ( wxMSWDarkMode::IsActive() )
     {
         // Note that we intentionally do not use this window HWND for the
@@ -646,6 +647,7 @@ wxVisualAttributes wxListCtrl::GetDefaultAttributes() const
         if ( col.IsOk() )
             attrs.colBg = col;
     }
+#endif
 
     return attrs;
 }

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -39,9 +39,7 @@
 
 #include "wx/msw/private/darkmode.h"
 
-#if wxUSE_UXTHEME
-    #include "wx/msw/uxtheme.h"
-#endif
+#include "wx/msw/uxtheme.h"
 
 // ----------------------------------------------------------------------------
 // macros
@@ -1714,11 +1712,7 @@ bool wxNotebook::SetBackgroundColour(const wxColour& colour)
 
 #if USE_NOTEBOOK_ANTIFLICKER
     Unbind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
-    if ( m_hasBgCol
-#if wxUSE_UXTHEME
-        || !wxUxThemeIsActive()
-#endif // wxUSE_UXTHEME
-        )
+    if ( m_hasBgCol || !wxUxThemeIsActive() )
     {
         Bind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
     }

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1714,7 +1714,11 @@ bool wxNotebook::SetBackgroundColour(const wxColour& colour)
 
 #if USE_NOTEBOOK_ANTIFLICKER
     Unbind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
-    if ( m_hasBgCol || !wxUxThemeIsActive() )
+    if ( m_hasBgCol
+#if wxUSE_UXTHEME
+        || !wxUxThemeIsActive()
+#endif // wxUSE_UXTHEME
+        )
     {
         Bind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
     }

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -696,6 +696,7 @@ wxStatusBar::GetClassDefaultAttributes(wxWindowVariant variant)
     wxVisualAttributes attrs =
         wxStatusBarBase::GetClassDefaultAttributes(variant);
 
+#if wxUSE_UXTHEME
     if ( wxMSWDarkMode::IsActive() )
     {
         // It looks like we don't have to use a valid HWND here.
@@ -709,6 +710,7 @@ wxStatusBar::GetClassDefaultAttributes(wxWindowVariant variant)
         if ( col.IsOk() )
             attrs.colBg = col;
     }
+#endif
 
     return attrs;
 }

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -144,9 +144,4 @@ wxUxThemeHandle::DrawBackground(HDC hdc, const wxRect& rect, int part, int state
     DrawBackground(hdc, rc, part, state);
 }
 
-#else
-bool wxUxThemeIsActive()
-{
-    return false;
-}
 #endif // wxUSE_UXTHEME


### PR DESCRIPTION
Probably broken since at least ca5f244 (Add wxUxThemeHandle::GetColour() replacing MSWGetThemeColour(), 2022-12-09).

Also fix linking by removing duplicate implementation for wxUxThemeIsActive() in .cpp.